### PR TITLE
Issue : Declaration of jsonSerialize() must be compatible #35

### DIFF
--- a/src/Slug.php
+++ b/src/Slug.php
@@ -101,7 +101,7 @@ class Slug extends Field
         return $this->withMeta(['asHtml' => true]);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize() : array
     {
         return array_merge([
             'disableAutoUpdateWhenUpdating' => $this->disableAutoUpdateWhenUpdating,


### PR DESCRIPTION
For the overload (or implementation of an interface) of a method to be valid, the signatures of the methods must be identical. Here, the jsonSerialize() method of the BenjaminHirsh/NovaSlugField/slug class must have the exact same signature as that of the Laravel/Nova/Fields/Field class.

To resolve this error, check the declaration of the jsonSerialize() method in the BenjaminHirsh/NovaSlugField/slug class and ensure that it has the same signature as that of the parent class Laravel/Nova/Fields/Field.